### PR TITLE
KubeMQ chart quality of life improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,13 @@ $ helm delete kubemq-release
 The following table lists the configurable parameters of the KubeMQ chart and their default values.
 
 
-| Parameter                           | Default           | Description                                                                                 |
+| Parameter                          | Default           | Description                                                                                 |
 |:-----------------------------------|:------------------|:--------------------------------------------------------------------------------------------|
-| nameOverride                       | `kubemq-cluster`  | Sets deployment name                                                                        |
+| nameOverride                       | `kubemq-cluster`  | Overrides deployment uses of name                                                           |
+| fullnameOverride                   | `kubemq-cluster`  | Overrides deployment uses of fullname                                                       |
+| existingSecret                     | ``                | Defines the name of a secret created outside of this chart                                  |
 | token                              | ``                | Sets KubeMQ token                                                                           |
+| licenseData                        | ``                | Sets KubeMQ license data for offline validation (optional)                                  |
 | replicaCount                       | `3`               | Number of KubeMQ nodes                                                                      |
 | cluster.enable                     | `true`            | Enable/Disable cluster mode                                                                 |
 | image.repository                   | `kubemq/kubemq`   | KubeMQ image name                                                                           |
@@ -50,6 +53,11 @@ The following table lists the configurable parameters of the KubeMQ chart and th
 | service.restPort                   | `9090`            | Sets KubeMQ service Rest Port                                                               |
 | service.grpcPort                   | `5000`            | Sets KubeMQ service gRPC Port                                                               |
 | service.clusterPort                | `5228`            | Sets KubeMQ service Cluster Port                                                            |
+| env.apiPort                        | `8080`            | Sets KubeMQ Api Port                                                                        |
+| env.restPort                       | `9090`            | Sets KubeMQ Rest Port                                                                       |
+| env.grpcPort                       | `5000`            | Sets KubeMQ gRPC Port                                                                       |
+| env.clusterPort                    | `5228`            | Sets KubeMQ Cluster Port                                                                    |
+| env.extra_env_vars                 | `{}`              | Dictionary defining arbitrary environment variables.                                        |
 | livenessProbe.enabled              | `true`            | Enable/Disable liveness prob                                                                |
 | livenessProbe.initialDelaySeconds  | `4`               | Delay before liveness probe is initiated                                                    |
 | livenessProbe.periodSeconds        | `10`              | How often to perform the probe                                                              |
@@ -67,6 +75,9 @@ The following table lists the configurable parameters of the KubeMQ chart and th
 | volume.size                        | `1Gi`             | Set volume size                                                                             |
 | volume.mountPath                   | ` "/store" `      | Sets container mounting point                                                               |
 | volume.accessMode                  | `"ReadWriteOnce"` | Sets Persistence access mode                                                                |
+| affinity                           | `{}`              | Affinity settings for the statefulset                                                       |
+| nodeSelector                       | `{}`              | Node selector settings for the statefulset                                                  |
+| tolerations                        | `[]`              | Toleration settings for the statefulset                                                     |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to helm install. For example,
 ```

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ The following table lists the configurable parameters of the KubeMQ chart and th
 | readinessProbe.failureThreshold    | `6`               | Minimum consecutive failures for the probe to be considered failed after having succeeded   |
 | readinessProbe.successThreshold    | `1`               | Minimum consecutive successes for the probe to be considered successful after having failed |
 | statefulset.updateStrategy         | `RollingUpdate`   | Statefulsets Update strategy                                                                |
+| statefulset.annotations            | `{}`              | Statefulsets annotations                                                                    |
 | volume.enabled                     | `false`           | Enable/Disable Persistence Volume Claim template                                            |
 | volume.size                        | `1Gi`             | Set volume size                                                                             |
 | volume.mountPath                   | ` "/store" `      | Sets container mounting point                                                               |

--- a/kubemq/Chart.yaml
+++ b/kubemq/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for KubeMQ
 name: kubemq
-version: 0.1.0
+version: 0.2.0

--- a/kubemq/templates/_helpers.tpl
+++ b/kubemq/templates/_helpers.tpl
@@ -1,7 +1,34 @@
 {{/* vim: set filetype=mustache: */}}
+
 {{- define "kubemq.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
 {{- define "kubemq.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kubemq.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Generate chart secret name
+*/}}
+{{- define "kubemq.secretName" -}}
+{{ default (include "kubemq.fullname" .) .Values.existingSecret }}
 {{- end -}}

--- a/kubemq/templates/environment-configmap.yaml
+++ b/kubemq/templates/environment-configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "kubemq.name" . }}-environment
+  name: {{ template "kubemq.fullname" . }}-environment
   labels:
     app.kubernetes.io/name: {{ include "kubemq.name" . }}
     helm.sh/chart: {{ include "kubemq.chart" . }}

--- a/kubemq/templates/environment-configmap.yaml
+++ b/kubemq/templates/environment-configmap.yaml
@@ -1,0 +1,17 @@
+{{- if not .Values.existingConfiguration }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "kubemq.name" . }}-environment
+  labels:
+    app.kubernetes.io/name: {{ include "kubemq.name" . }}
+    helm.sh/chart: {{ include "kubemq.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+{{- if .Values.env.extra_env_vars }}
+{{- with .Values.env.extra_env_vars }}
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/kubemq/templates/secrets.yaml
+++ b/kubemq/templates/secrets.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "kubemq.name" . }}
+  name: {{ template "kubemq.fullname" . }}
   labels:
     app: {{ template "kubemq.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/kubemq/templates/secrets.yaml
+++ b/kubemq/templates/secrets.yaml
@@ -10,10 +10,8 @@ metadata:
     heritage: "{{ .Release.Service }}"
 type: Opaque
 stringData:
-  {{- if .Values.token }}
-  licenseToken: {{ .Values.token | quote }}
-  {{ end }}
+  KUBEMQ_TOKEN: {{ .Values.token | quote }}
   {{- if .Values.licenseData }}
-  licenseData: {{ .Values.licenseData | quote }}
+  KUBEMQ_LICENSE_DATA: {{ .Values.licenseData | quote }}
   {{ end }}
 {{ end }}

--- a/kubemq/templates/secrets.yaml
+++ b/kubemq/templates/secrets.yaml
@@ -1,0 +1,19 @@
+{{- if not .Values.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "kubemq.name" . }}
+  labels:
+    app: {{ template "kubemq.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+stringData:
+  {{- if .Values.token }}
+  licenseToken: {{ .Values.token | quote }}
+  {{ end }}
+  {{- if .Values.licenseData }}
+  licenseData: {{ .Values.licenseData | quote }}
+  {{ end }}
+{{ end }}

--- a/kubemq/templates/service.yaml
+++ b/kubemq/templates/service.yaml
@@ -1,7 +1,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "kubemq.name" . }}
+  name: {{ include "kubemq.fullname" . }}
+  labels:
+    app: {{ template "kubemq.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
 spec:
   type: {{ .Values.service.type }}
   ports:
@@ -24,3 +29,4 @@ spec:
   sessionAffinity: None
   selector:
     app: {{ include "kubemq.name" . }}
+    release: {{ .Release.Name }}

--- a/kubemq/templates/statefulset.yaml
+++ b/kubemq/templates/statefulset.yaml
@@ -2,6 +2,10 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "kubemq.name" . }}
+  app: {{ include "kubemq.name" . }}
+  chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+  heritage: {{ .Release.Service }}
+  release: {{ .Release.Name }}
 spec:
   selector:
     matchLabels:
@@ -30,8 +34,20 @@ spec:
 
       containers:
         - env:
+            {{- if .Values.token }}
             - name: KUBEMQ_TOKEN
-              value: {{ .Values.token }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "kubemq.secretName" . }}
+                  key: licenseToken
+            {{ end }}
+            {{- if .Values.licenseData }}
+            - name: KUBEMQ_LICENSE_DATA
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "kubemq.secretName" . }}
+                  key: licenseData
+            {{ end }}
             - name: CLUSTER_ROUTES
               value: {{ include "kubemq.name" .}}:{{ .Values.service.clusterPort }}
             - name: CLUSTER_PORT

--- a/kubemq/templates/statefulset.yaml
+++ b/kubemq/templates/statefulset.yaml
@@ -1,87 +1,101 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-    name: {{ include "kubemq.name" . }}
+  name: {{ include "kubemq.name" . }}
 spec:
-    selector:
-        matchLabels:
-            app: {{ include "kubemq.name" . }}
-    replicas: {{ .Values.replicaCount }}
-    serviceName: {{ include "kubemq.name" . }}
-    updateStrategy:
-        type: {{ .Values.statefulset.updateStrategy }}
-    template:
-        metadata:
-            labels:
-                app: {{ include "kubemq.name" . }}
-        spec:
-            containers:
-                  - env:
-                      - name: KUBEMQ_TOKEN
-                        value: {{ .Values.token }}
-                      - name: CLUSTER_ROUTES
-                        value: {{ include "kubemq.name" .}}:{{ .Values.service.clusterPort }}
-                      - name: CLUSTER_PORT
-                        value: {{ .Values.env.clusterPort | quote}}
-                      - name: CLUSTER_ENABLE
-                        value: {{ .Values.cluster.enable | quote}}
-                      - name: GRPC_PORT
-                        value: {{ .Values.env.grpcPort | quote}}
-                      - name: REST_PORT
-                        value: {{ .Values.env.restPort | quote}}
-                      - name: KUBEMQ_PORT
-                        value: {{ .Values.env.apiPort | quote}}
-                    image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
-                    imagePullPolicy: {{ .Values.image.pullPolicy }}
-                    name: {{ .Chart.Name }}
-                  {{- if .Values.livenessProbe.enabled }}
-                    livenessProbe:
-                        httpGet:
-                            path: /health
-                            port: {{ .Values.env.apiPort }}
-                        initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
-                        periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
-                        timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
-                        successThreshold: {{ .Values.livenessProbe.successThreshold }}
-                        failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
-                  {{- end }}
-                  {{- if .Values.readinessProbe.enabled }}
-                    readinessProbe:
-                        httpGet:
-                            path: /health
-                            port: {{ .Values.env.apiPort }}
-                        initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
-                        periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
-                        timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
-                        successThreshold: {{ .Values.readinessProbe.successThreshold }}
-                        failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
-                  {{- end }}
-                    ports:
-                      - containerPort: {{ .Values.env.grpcPort }}
-                        name: grpc-port
-                        protocol: TCP
-                      - containerPort: {{ .Values.env.apiPort }}
-                        name: api-port
-                        protocol: TCP
-                      - containerPort: {{ .Values.env.restPort }}
-                        name: rest-port
-                        protocol: TCP
-                      - containerPort: {{ .Values.env.clusterPort }}
-                        name: cluster-port
-                        protocol: TCP
-                    {{- if .Values.volume.enabled }}
-                    volumeMounts:
-                      - mountPath: {{ .Values.volume.mountPath }}
-                        name: {{ include "kubemq.name" . }}-vol
-                    {{- end }}
-            restartPolicy: Always
-    {{- if .Values.volume.enabled }}
-    volumeClaimTemplates:
-        - metadata:
-            name: {{ include "kubemq.name" . }}-vol
-          spec:
-              accessModes: [ {{ .Values.volume.accessMode }} ]
-              resources:
-                  requests:
-                      storage: {{ .Values.volume.size }}
-    {{- end }}
+  selector:
+    matchLabels:
+      app: {{ include "kubemq.name" . }}
+  replicas: {{ .Values.replicaCount }}
+  serviceName: {{ include "kubemq.name" . }}
+  updateStrategy:
+    type: {{ .Values.statefulset.updateStrategy }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "kubemq.name" . }}
+    spec:
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      containers:
+        - env:
+            - name: KUBEMQ_TOKEN
+              value: {{ .Values.token }}
+            - name: CLUSTER_ROUTES
+              value: {{ include "kubemq.name" .}}:{{ .Values.service.clusterPort }}
+            - name: CLUSTER_PORT
+              value: {{ .Values.env.clusterPort | quote}}
+            - name: CLUSTER_ENABLE
+              value: {{ .Values.cluster.enable | quote}}
+            - name: GRPC_PORT
+              value: {{ .Values.env.grpcPort | quote}}
+            - name: REST_PORT
+              value: {{ .Values.env.restPort | quote}}
+            - name: KUBEMQ_PORT
+              value: {{ .Values.env.apiPort | quote}}
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          name: {{ .Chart.Name }}
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.env.apiPort }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.env.apiPort }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- end }}
+          ports:
+            - containerPort: {{ .Values.env.grpcPort }}
+              name: grpc-port
+              protocol: TCP
+            - containerPort: {{ .Values.env.apiPort }}
+              name: api-port
+              protocol: TCP
+            - containerPort: {{ .Values.env.restPort }}
+              name: rest-port
+              protocol: TCP
+            - containerPort: {{ .Values.env.clusterPort }}
+              name: cluster-port
+              protocol: TCP
+          {{- if .Values.volume.enabled }}
+          volumeMounts:
+            - mountPath: {{ .Values.volume.mountPath }}
+              name: {{ include "kubemq.name" . }}-vol
+          {{- end }}
+      restartPolicy: Always
+
+  {{- if .Values.volume.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: {{ include "kubemq.name" . }}-vol
+      spec:
+        accessModes: [ {{ .Values.volume.accessMode }} ]
+        resources:
+          requests:
+            storage: {{ .Values.volume.size }}
+  {{- end }}

--- a/kubemq/templates/statefulset.yaml
+++ b/kubemq/templates/statefulset.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ include "kubemq.name" . }}
+  name: {{ include "kubemq.fullname" . }}
   app: {{ include "kubemq.name" . }}
   chart: {{ .Chart.Name }}-{{ .Chart.Version }}
   heritage: {{ .Release.Service }}
@@ -10,14 +10,16 @@ spec:
   selector:
     matchLabels:
       app: {{ include "kubemq.name" . }}
+      release: {{ .Release.Name }}
   replicas: {{ .Values.replicaCount }}
-  serviceName: {{ include "kubemq.name" . }}
+  serviceName: {{ include "kubemq.fullname" . }}
   updateStrategy:
     type: {{ .Values.statefulset.updateStrategy }}
   template:
     metadata:
       labels:
         app: {{ include "kubemq.name" . }}
+        release: {{ .Release.Name }}
     spec:
       {{- with .Values.nodeSelector }}
       nodeSelector:
@@ -60,6 +62,7 @@ spec:
               value: {{ .Values.env.restPort | quote}}
             - name: KUBEMQ_PORT
               value: {{ .Values.env.apiPort | quote}}
+
           envFrom:
             - configMapRef:
                 name: "{{ template "kubemq.fullname" . }}-environment"
@@ -105,14 +108,14 @@ spec:
           {{- if .Values.volume.enabled }}
           volumeMounts:
             - mountPath: {{ .Values.volume.mountPath }}
-              name: {{ include "kubemq.name" . }}-vol
+              name: {{ include "kubemq.fullname" . }}-vol
           {{- end }}
       restartPolicy: Always
 
   {{- if .Values.volume.enabled }}
   volumeClaimTemplates:
     - metadata:
-        name: {{ include "kubemq.name" . }}-vol
+        name: {{ include "kubemq.fullname" . }}-vol
       spec:
         accessModes: [ {{ .Values.volume.accessMode }} ]
         resources:

--- a/kubemq/templates/statefulset.yaml
+++ b/kubemq/templates/statefulset.yaml
@@ -36,20 +36,6 @@ spec:
 
       containers:
         - env:
-            {{- if .Values.token }}
-            - name: KUBEMQ_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "kubemq.secretName" . }}
-                  key: licenseToken
-            {{ end }}
-            {{- if .Values.licenseData }}
-            - name: KUBEMQ_LICENSE_DATA
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "kubemq.secretName" . }}
-                  key: licenseData
-            {{ end }}
             - name: CLUSTER_ROUTES
               value: {{ include "kubemq.name" .}}:{{ .Values.service.clusterPort }}
             - name: CLUSTER_PORT
@@ -64,6 +50,8 @@ spec:
               value: {{ .Values.env.apiPort | quote}}
 
           envFrom:
+            - secretRef:
+                name: {{ template "kubemq.secretName" . }}
             - configMapRef:
                 name: "{{ template "kubemq.fullname" . }}-environment"
 

--- a/kubemq/templates/statefulset.yaml
+++ b/kubemq/templates/statefulset.yaml
@@ -20,6 +20,11 @@ spec:
       labels:
         app: {{ include "kubemq.name" . }}
         release: {{ .Release.Name }}
+      {{- with .Values.statefulset.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
     spec:
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/kubemq/templates/statefulset.yaml
+++ b/kubemq/templates/statefulset.yaml
@@ -60,6 +60,10 @@ spec:
               value: {{ .Values.env.restPort | quote}}
             - name: KUBEMQ_PORT
               value: {{ .Values.env.apiPort | quote}}
+          envFrom:
+            - configMapRef:
+                name: "{{ template "kubemq.fullname" . }}-environment"
+
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           name: {{ .Chart.Name }}

--- a/kubemq/values.yaml
+++ b/kubemq/values.yaml
@@ -1,12 +1,18 @@
 nameOverride: "kubemq-cluster"
+
+existingSecret: ""
 token: ""
+licenseData: ""
+
 replicaCount: 3
 cluster:
   enable: 'true'
+
 image:
   repository: kubemq/kubemq
   tag: latest
   pullPolicy: Always
+
 service:
   type: ClusterIP
   apiPort: 8080
@@ -27,6 +33,7 @@ livenessProbe:
   timeoutSeconds: 5
   failureThreshold: 6
   successThreshold: 1
+
 readinessProbe:
   enabled: true
   initialDelaySeconds: 1

--- a/kubemq/values.yaml
+++ b/kubemq/values.yaml
@@ -43,3 +43,7 @@ volume:
   size: 1Gi
   mountPath: '/store'
   accessMode: "ReadWriteOnce"
+
+nodeSelector: {}
+affinity: {}
+tolerations: []

--- a/kubemq/values.yaml
+++ b/kubemq/values.yaml
@@ -1,4 +1,5 @@
 nameOverride: "kubemq-cluster"
+fullnameOverride: "kubemq-cluster"
 
 existingSecret: ""
 token: ""
@@ -7,6 +8,7 @@ licenseData: ""
 replicaCount: 3
 cluster:
   enable: 'true'
+
 
 image:
   repository: kubemq/kubemq
@@ -25,6 +27,9 @@ env:
   restPort: 9090
   grpcPort: 50000
   clusterPort: 5228
+  extra_env_vars: {}
+    # Add arbitrary environment variables here:
+    # <KEY>: VALUE
 
 livenessProbe:
   enabled: true

--- a/kubemq/values.yaml
+++ b/kubemq/values.yaml
@@ -49,6 +49,7 @@ readinessProbe:
 
 statefulset:
   updateStrategy: RollingUpdate
+  annotations: {}
 
 volume:
   enabled: false


### PR DESCRIPTION
This PR aims to solve some problems that we were having with deploying KubeMQ via the existing chart. There are numerous improvements that I'll attempt to outline below:

- Add support for `nodeSelector`, `affinity`, `tolerations`: This was required in order for us to place our pods in a deterministic way.
- Move token into a secret, add support for providing license data: This is the prescribed k8s way to manage sensitive data. Also provides a facility for offline license validation which was documented, but difficult to find and not supported by the existing chart.
- Added support for generating a configmap with arbitrary environment variables. This is useful in defining options that are not directly supported by the helm chart.
- Enabled the use of more specific (`fullname`) resource names. This is pretty common in other charts, and better enables users to define distinct KubeMQ clusters within a common namespace. The default behaviour should be consistent with the existing naming convention by setting both `nameOverride` and `fullnameOverride` to `kubemq-cluster`. Setting these values to `""` will use the calculated names.
- Adds annotation support for the `statefulset` pods.
- Updated the README to reflect these improvements.
- Bumped the chart version to `0.2.0`.