### PR TITLE
Fixing a bug with labels for helm3 compatibility.

### DIFF
--- a/kubemq/Chart.yaml
+++ b/kubemq/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for KubeMQ
 name: kubemq
-version: 0.2.0
+version: 0.2.1

--- a/kubemq/templates/statefulset.yaml
+++ b/kubemq/templates/statefulset.yaml
@@ -2,10 +2,11 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "kubemq.fullname" . }}
-  app: {{ include "kubemq.name" . }}
-  chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-  heritage: {{ .Release.Service }}
-  release: {{ .Release.Name }}
+  labels:
+    app: {{ include "kubemq.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
This PR is a minor change to account for Helm3 and their more strict adherence to k8s resource definitions. This was not caught in Helm2 as it was not as strict about arbitrary keys.

This solves the error message:

```
Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: [ValidationError(StatefulSet.metadata): unknown field "app" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta, ValidationError(StatefulSet.metadata): unknown field "chart" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta, ValidationError(StatefulSet.metadata): unknown field "heritage" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta, ValidationError(StatefulSet.metadata): unknown field "release" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta]
```