### PR TITLE
Update kubemqcluster.yaml

### DIFF
--- a/kubemq/templates/kubemqcluster.yaml
+++ b/kubemq/templates/kubemqcluster.yaml
@@ -1,4 +1,4 @@
-apiVersion: core.k8s.kubemq.io/v1beta1
+apiVersion: core.k8s.kubemq.io/v1alpha1
 kind: KubemqCluster
 metadata:
   name: {{ include "kubemq.fullname" . }}


### PR DESCRIPTION
### Error
`Error: INSTALLATION FAILED: unable to build kubernetes objects from release manifest: resource mapping not found for name: "kubemq-cluster" namespace: "kubemq-system" from "": no matches for kind "KubemqCluster" in version "core.k8s.kubemq.io/v1beta1"`

![image](https://user-images.githubusercontent.com/9063986/211228034-3cc331bb-b517-4571-b8bb-dfdfa84b9824.png)

### Fixed
in kubemq/templates/kubemqcluster.yaml
- core.k8s.kubemq.io/`v1beta1` → core.k8s.kubemq.io/`v1alpha1`

### Test
![image](https://user-images.githubusercontent.com/9063986/211228106-eb51417b-c638-4552-8f81-8575c07ba058.png)

### Issue
[Helm install fails (no matches for kind "KubemqCluster")](https://github.com/kubemq-io/charts/issues/9)
